### PR TITLE
Template Haskell fix.

### DIFF
--- a/Data/Global.hs
+++ b/Data/Global.hs
@@ -117,7 +117,7 @@ declare mty newRef nameStr = do
     return [
         SigD name ty
       , ValD (VarP name) (NormalB body) []
-      , PragmaD (InlineP name (InlineSpec False False Nothing)) ]
+      , PragmaD (InlineP name Inline FunLike AllPhases) ]
 
 declareRef :: Name -> Q Exp -> String -> Q Type -> Q [Dec]
 declareRef refTy newRef nameStr mty

--- a/safe-globals.cabal
+++ b/safe-globals.cabal
@@ -1,5 +1,5 @@
 name:                safe-globals
-version:             0.1.1
+version:             0.1.2
 license:             BSD3
 license-file:        LICENSE
 synopsis:            Safe top-level mutable variables which scope like ordinary values
@@ -53,7 +53,7 @@ library
   build-depends:
       base >= 3 && < 5
     , stm  >= 2.1
-    , template-haskell >= 2.4
+    , template-haskell >= 2.8
 
   other-extensions:
       TemplateHaskell


### PR DESCRIPTION
Template Haskell 2.8 changed the definition of the InlineP constructor. This commit:
- updates the "declare" function to use the new interface;
- sets the minimum required version of template-haskell to 2.8;
- bumps the safe-globals version to 0.1.2.
